### PR TITLE
Include the compiler name in the output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Changes:
+* Add compiler name to the warning (#11)[https://github.com/axelson/priv_check/pull/11]
+
 # 0.2.2 2020-04-18
 
 Changes:

--- a/lib/priv_check/reference_checker.ex
+++ b/lib/priv_check/reference_checker.ex
@@ -50,7 +50,7 @@ defmodule PrivCheck.ReferenceChecker do
         nil
       else
         message =
-          "#{inspect(mod)}.#{fun}/#{arity} is not a public function\n" <>
+          "(PrivCheck) #{inspect(mod)}.#{fun}/#{arity} is not a public function\n" <>
             "  and should not be called from other applications.\n" <>
             "  Called from: #{inspect(called_from_module)}."
 
@@ -82,7 +82,7 @@ defmodule PrivCheck.ReferenceChecker do
 
         :private ->
           message =
-            "#{referenced_module} is not a public module\n" <>
+            "(PrivCheck) #{referenced_module} is not a public module\n" <>
               "  and should not be referenced from other applications."
 
           diagnostic_error(

--- a/test/priv_check/integration_phoenix_umbrella_test.exs
+++ b/test/priv_check/integration_phoenix_umbrella_test.exs
@@ -21,13 +21,15 @@ defmodule PrivCheck.IntegrationPhoenixUmbrellaTest do
     assert Enum.member?(warnings, %{
              location: "lib/brella_demo_web/controllers/page_controller.ex:7",
              warning:
-               "Elixir.BrellaDemo.NonPublic is not a public module and should not be referenced from other applications."
+               "(PrivCheck) Elixir.BrellaDemo.NonPublic is not a public module and should not be " <>
+                 "referenced from other applications."
            })
 
     assert Enum.member?(warnings, %{
              location: "lib/brella_demo_web/controllers/page_controller.ex:7",
              warning:
-               "BrellaDemo.NonPublic.a_function/0 is not a public function and should not be called from other applications. Called from: BrellaDemoWeb.PageController."
+               "(PrivCheck) BrellaDemo.NonPublic.a_function/0 is not a public function and should not be " <>
+                 "called from other applications. Called from: BrellaDemoWeb.PageController."
            })
 
     assert length(warnings) == 2

--- a/test/priv_check/integration_priv_check_example_test.exs
+++ b/test/priv_check/integration_priv_check_example_test.exs
@@ -21,37 +21,43 @@ defmodule PrivCheck.IntegrationPrivCheckExampleTest do
     assert Enum.member?(warnings, %{
              location: "lib/priv_check_example.ex:17",
              warning:
-               "Elixir.ExampleDep.Private is not a public module and should not be referenced from other applications."
+               "(PrivCheck) Elixir.ExampleDep.Private is not a public module and should not be " <>
+                 "referenced from other applications."
            })
 
     assert Enum.member?(warnings, %{
              location: "lib/priv_check_example.ex:20",
              warning:
-               "ExampleDep.Mixed.private/0 is not a public function and should not be called from other applications. Called from: PrivCheckExample."
+               "(PrivCheck) ExampleDep.Mixed.private/0 is not a public function and should not be " <>
+                 "called from other applications. Called from: PrivCheckExample."
            })
 
     assert Enum.member?(warnings, %{
              location: "lib/priv_check_example.ex:21",
              warning:
-               "Elixir.ExampleDep.Private is not a public module and should not be referenced from other applications."
+               "(PrivCheck) Elixir.ExampleDep.Private is not a public module and should not be " <>
+                 "referenced from other applications."
            })
 
     assert Enum.member?(warnings, %{
              location: "lib/priv_check_example.ex:21",
              warning:
-               "ExampleDep.Private.add/2 is not a public function and should not be called from other applications. Called from: PrivCheckExample."
+               "(PrivCheck) ExampleDep.Private.add/2 is not a public function and should not be " <>
+                 "called from other applications. Called from: PrivCheckExample."
            })
 
     assert Enum.member?(warnings, %{
              location: "lib/priv_check_example.ex:22",
              warning:
-               "Elixir.ExampleDep.Private is not a public module and should not be referenced from other applications."
+               "(PrivCheck) Elixir.ExampleDep.Private is not a public module and should not be " <>
+                 "referenced from other applications."
            })
 
     assert Enum.member?(warnings, %{
              location: "lib/priv_check_example.ex:22",
              warning:
-               "ExampleDep.Private.with_doc/0 is not a public function and should not be called from other applications. Called from: PrivCheckExample."
+               "(PrivCheck) ExampleDep.Private.with_doc/0 is not a public function and should not be " <>
+                 "called from other applications. Called from: PrivCheckExample."
            })
 
     assert length(warnings) == 6


### PR DESCRIPTION
This makes it easier for an end user to know what is generating the warning

Fixes #10